### PR TITLE
[Fix] 如果剪切板被占用则会抛出异常。

### DIFF
--- a/IMEI_Calc/Form1.cs
+++ b/IMEI_Calc/Form1.cs
@@ -49,8 +49,15 @@ namespace IMEI_Calc
         {
             if (textBoxOutput.Text != "")
             {
-                Clipboard.SetDataObject(textBoxOutput.Text);
-                //MessageBox.Show("已复制到剪贴板！");
+                try
+                {
+                    Clipboard.SetDataObject(textBoxOutput.Text);
+                    //MessageBox.Show("已复制到剪贴板！");
+                }
+                catch
+                {
+                    MessageBox.Show("剪切板被占用，复制失败！")
+                }
                 timer1.Interval = 1000;
                 timer1.Enabled = true;
             }


### PR DESCRIPTION
如果剪切板被占用可能会导致异常出现，故使用try进行捕捉可以避免程序崩溃。